### PR TITLE
Skip rotating dataset and calculating Z and XYZ stats for images with only one channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cmake-build-*/
 .idea/
+build/


### PR DESCRIPTION
This fixes #1. The Python converter should be updated to skip swizzles; it currently only skips the statistics.

This has been tested with multiple images; it could use a further test with an image with one channel and multiple stokes.