### PR TITLE
Confluence/typed header attributes

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -160,6 +160,8 @@ int main(int argc, char** argv) {
                     trim(attributeName);
                     trim(attributeValue);
                     
+                    bool parsingFailure(false);
+                    
                     if (attributeValue.length() >= 2 && attributeValue.find('\'') == 0 &&
                         attributeValue.find_last_of('\'') == attributeValue.length() - 1) {
                         // STRING
@@ -181,6 +183,7 @@ int main(int argc, char** argv) {
                             attribute.write(doubleType, &attributeValueDouble);
                         } catch (const std::invalid_argument& ia) {
                             cout << "Warning: Could not parse attribute '" << attributeName << "' as a float." << endl;
+                            parsingFailure = true;
                         }
                     } else {
                         // TRY TO PARSE AS INTEGER
@@ -190,10 +193,14 @@ int main(int argc, char** argv) {
                             attribute.write(int64Type, &attributeValueInt);
                         } catch (const std::invalid_argument& ia) {
                             cout << "Warning: Could not parse attribute '" << attributeName << "' as an integer." << endl;
-                            // FALL BACK TO STRING
-                            attribute = outputGroup.createAttribute(attributeName, strType, attributeDataSpace);
-                            attribute.write(strType, attributeValue);
+                            parsingFailure = true;
                         }
+                    }
+                    
+                    if (parsingFailure) {
+                        // FALL BACK TO STRING
+                        attribute = outputGroup.createAttribute(attributeName, strType, attributeDataSpace);
+                        attribute.write(strType, attributeValue);
                     }
                 }
             }

--- a/main.cc
+++ b/main.cc
@@ -190,6 +190,9 @@ int main(int argc, char** argv) {
                             attribute.write(int64Type, &attributeValueInt);
                         } catch (const std::invalid_argument& ia) {
                             cout << "Warning: Could not parse attribute '" << attributeName << "' as an integer." << endl;
+                            // FALL BACK TO STRING
+                            attribute = outputGroup.createAttribute(attributeName, strType, attributeDataSpace);
+                            attribute.write(strType, attributeValue);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #2 .

* If an attribute is quoted, remove the quotes and write as a string (as before)
* Otherwise if it's T or F, write as a boolean (actually an integer type under the hood)
* Otherwise assume that it's a number, and try to parse it as a double (if it contains a full stop) or as an integer (if it does not).
* If this parsing fails, fall back to string.

Since this is a change which requires a schema bump, we should merge it only into dev.