### PR TITLE
Fix for attributes which fail to parse with std::stod

### DIFF
--- a/Converter.cc
+++ b/Converter.cc
@@ -173,7 +173,7 @@ void Converter::copyHeaders() {
                         attribute = outputGroup.createAttribute(attributeName, doubleType, attributeDataSpace);
                         attribute.write(doubleType, &attributeValueDouble);
                     } catch (const std::invalid_argument& ia) {
-                        std::cout << "Warning: Could not parse attribute '" << attributeName << "' as a float." << std::endl;
+                        std::cout << "Warning: could not parse attribute '" << attributeName << "' as a float." << std::endl;
                         parsingFailure = true;
                     } catch (const std::out_of_range& e) {
                         long double attributeValueLongDouble = std::stold(attributeValue);
@@ -181,11 +181,23 @@ void Converter::copyHeaders() {
                         attribute = outputGroup.createAttribute(attributeName, doubleType, attributeDataSpace);
                         attribute.write(doubleType, &attributeValueDouble);
                         
+                        auto upper = [](std::string& s) {
+                            std::for_each(s.begin(), s.end(), [](char& c){
+                                c = ::toupper(c);
+                            });
+                        };
+                        
                         std::ostringstream ostream;
                         ostream.precision(13);
                         ostream << attributeValueDouble;
-                        
-                        std::cout << "Warning: Attribute  '" << attributeName << "' with value '" << attributeValue << "', is not representable as a double precision floating point number on this architecture. Falling back to parsing as a long double and converting to double. Final value is '" << ostream.str() << "'." << std::endl;
+                        std::string original(attributeValue);
+                        std::string round_trip(ostream.str());
+                        upper(original);
+                        upper(round_trip);
+                                                
+                        if (original != round_trip) {
+                            std::cout << "Warning: the value of attribute  '" << attributeName << "' is not representable as a normalised double precision floating point number. Some precision has been lost.\nOriginal string representation:\n'" << original << "'\nFinal string representation:\n'" << round_trip << "'" << std::endl;
+                        }
                     }
                 } else {
                     // TRY TO PARSE AS INTEGER
@@ -194,7 +206,7 @@ void Converter::copyHeaders() {
                         attribute = outputGroup.createAttribute(attributeName, intType, attributeDataSpace);
                         attribute.write(intType, &attributeValueInt);
                     } catch (const std::invalid_argument& ia) {
-                        std::cout << "Warning: Could not parse attribute '" << attributeName << "' as an integer." << std::endl;
+                        std::cout << "Warning: could not parse attribute '" << attributeName << "' as an integer." << std::endl;
                         parsingFailure = true;
                     }
                 }

--- a/Converter.cc
+++ b/Converter.cc
@@ -181,19 +181,13 @@ void Converter::copyHeaders() {
                         attribute = outputGroup.createAttribute(attributeName, doubleType, attributeDataSpace);
                         attribute.write(doubleType, &attributeValueDouble);
                         
-                        auto upper = [](std::string& s) {
-                            std::for_each(s.begin(), s.end(), [](char& c){
-                                c = ::toupper(c);
-                            });
-                        };
-                        
                         std::ostringstream ostream;
                         ostream.precision(13);
                         ostream << attributeValueDouble;
                         std::string original(attributeValue);
                         std::string round_trip(ostream.str());
-                        upper(original);
-                        upper(round_trip);
+                        transform(original.begin(), original.end(), original.begin(), ::toupper);
+                        transform(round_trip.begin(), round_trip.end(), round_trip.begin(), ::toupper);
                                                 
                         if (original != round_trip) {
                             std::cout << "Warning: the value of attribute  '" << attributeName << "' is not representable as a normalised double precision floating point number. Some precision has been lost.\nOriginal string representation:\n'" << original << "'\nFinal string representation:\n'" << round_trip << "'" << std::endl;

--- a/Converter.cc
+++ b/Converter.cc
@@ -175,6 +175,17 @@ void Converter::copyHeaders() {
                     } catch (const std::invalid_argument& ia) {
                         std::cout << "Warning: Could not parse attribute '" << attributeName << "' as a float." << std::endl;
                         parsingFailure = true;
+                    } catch (const std::out_of_range& e) {
+                        long double attributeValueLongDouble = std::stold(attributeValue);
+                        double attributeValueDouble = (double) attributeValueLongDouble;
+                        attribute = outputGroup.createAttribute(attributeName, doubleType, attributeDataSpace);
+                        attribute.write(doubleType, &attributeValueDouble);
+                        
+                        std::ostringstream ostream;
+                        ostream.precision(13);
+                        ostream << attributeValueDouble;
+                        
+                        std::cout << "Warning: Attribute  '" << attributeName << "' with value '" << attributeValue << "', is not representable as a double precision floating point number on this architecture. Falling back to parsing as a long double and converting to double. Final value is '" << ostream.str() << "'." << std::endl;
                     }
                 } else {
                     // TRY TO PARSE AS INTEGER

--- a/common.h
+++ b/common.h
@@ -16,7 +16,7 @@
 
 #define SCHEMA_VERSION "0.3"
 #define HDF5_CONVERTER "hdf_convert"
-#define HDF5_CONVERTER_VERSION "0.1.10"
+#define HDF5_CONVERTER_VERSION "0.1.11"
 
 #define TILE_SIZE (hsize_t)512
 #define MIN_MIPMAP_SIZE (hsize_t)128


### PR DESCRIPTION
A file with a very small floating point attribute triggered the exception described [here](https://stackoverflow.com/questions/48086830/stdstod-throws-out-of-range-error-for-a-string-that-should-be-valid) and caused the converter to crash. I have added a fallback to parse such values as `long double` and cast them to `double`. In this particular case the final double, when converted to a string with the same precision as the original string, is identical to the original string.