### PR TITLE
Confluence/fix inf

### DIFF
--- a/FastConverter.cc
+++ b/FastConverter.cc
@@ -103,7 +103,7 @@ void FastConverter::copyAndCalculate() {
                         rotatedCube[destIndex] = val;
                     }
                     
-                    if (!std::isnan(val)) {
+                    if (std::isfinite(val)) {
                         minmax(val);
                         sum += val;
                         sumSq += val * val;
@@ -144,9 +144,8 @@ void FastConverter::copyAndCalculate() {
 
             for (auto i = 0; i < depth; i++) {
                 auto indexXY = currentStokes * depth + i;
-                auto sum = statsXY.sums[indexXY];
-                if (!std::isnan(sum)) {
-                    xyzSum += sum;
+                if (std::isfinite(statsXY.maxVals[indexXY])) {
+                    xyzSum += statsXY.sums[indexXY];
                     xyzSumSq += statsXY.sumsSq[indexXY];
                     xyzMin = fmin(xyzMin, statsXY.minVals[indexXY]);
                     xyzMax = fmax(xyzMax, statsXY.maxVals[indexXY]);
@@ -182,10 +181,10 @@ void FastConverter::copyAndCalculate() {
                         auto sourceIndex = k + width * j + (height * width) * i;
                         auto val = standardCube[sourceIndex];
 
-                        if (!std::isnan(val)) {
+                        if (std::isfinite(val)) {
                             // Not replacing this with if/else; too much risk of encountering an ascending / descending sequence.
-                            minVal = std::min(minVal, val);
-                            maxVal = std::max(maxVal, val);
+                            minVal = fmin(minVal, val);
+                            maxVal = fmax(maxVal, val);
                             sum += val;
                             sumSq += val * val;
                         } else {
@@ -255,7 +254,7 @@ void FastConverter::copyAndCalculate() {
             bool chanHist(true);
             bool cubeHist(true);
             
-            if (std::isnan(sliceMin) || std::isnan(sliceMax) || range == 0) {
+            if (!std::isfinite(sliceMin) || !std::isfinite(sliceMax) || range == 0) {
                 channelHistogramFunc = doNothing;
                 chanHist = false;
             }
@@ -272,7 +271,7 @@ void FastConverter::copyAndCalculate() {
             for (auto j = 0; j < width * height; j++) {
                 auto val = standardCube[i * width * height + j];
 
-                if (!std::isnan(val)) {
+                if (std::isfinite(val)) {
                     channelHistogramFunc(val);
                     cubeHistogramFunc(val);
                 }
@@ -355,7 +354,7 @@ void FastConverter::copyAndCalculate() {
                 for (auto x = 0; x < width; x++) {
                     auto sourceIndex = x + width * y + (height * width) * c;
                     auto val = standardCube[sourceIndex];
-                    if (!std::isnan(val)) {
+                    if (std::isfinite(val)) {
                         for (auto& mipMap : mipMaps) {
                             mipMap.accumulate(val, x, y, c);
                         }

--- a/SlowConverter.cc
+++ b/SlowConverter.cc
@@ -123,7 +123,7 @@ void SlowConverter::copyAndCalculate() {
                     
                     auto val = standardCube[pos];
                                         
-                    if (!std::isnan(val)) {
+                    if (std::isfinite(val)) {
                         // XY statistics
                         // TODO: check if indexing stats arrays inside loop is slow or is optimised away
                         minmax(val);
@@ -163,7 +163,7 @@ void SlowConverter::copyAndCalculate() {
             // Accumulate XYZ statistics
             if (depth > 1) {
                 D(std::cout << " Accumulating XYZ stats..." << std::flush;);
-                if (!std::isnan(statsXY.sums[indexXY])) {
+                if (std::isfinite(statsXY.maxVals[indexXY])) {
                     statsXYZ.sums[s] += statsXY.sums[indexXY];
                     statsXYZ.sumsSq[s] += statsXY.sumsSq[indexXY];
                     statsXYZ.minVals[s] = fmin(statsXYZ.minVals[s], statsXY.minVals[indexXY]);
@@ -236,7 +236,7 @@ void SlowConverter::copyAndCalculate() {
             cubeMin = statsXYZ.minVals[s];
             cubeMax = statsXYZ.maxVals[s];
             cubeRange = cubeMax - cubeMin;
-            cubeHist = !std::isnan(cubeMin) && !std::isnan(cubeMax) && cubeRange > 0;
+            cubeHist = std::isfinite(cubeMin) && std::isfinite(cubeMax) && cubeRange > 0;
         }
         
         D(std::cout << "+ Will " << (cubeHist ? "" : "not ") << "calculate cube histogram." << std::endl;);
@@ -248,7 +248,7 @@ void SlowConverter::copyAndCalculate() {
             double chanMin = statsXY.minVals[indexXY];
             double chanMax = statsXY.maxVals[indexXY];
             double chanRange = chanMax - chanMin;
-            bool chanHist(!std::isnan(chanMin) && !std::isnan(chanMax) && chanRange > 0);
+            bool chanHist(std::isfinite(chanMin) && std::isfinite(chanMax) && chanRange > 0);
             
             D(std::cout << " Will " << (chanHist ? "" : "not ") << "calculate channel histogram." << std::flush;);
             
@@ -294,7 +294,7 @@ void SlowConverter::copyAndCalculate() {
             D(std::cout << " Calculating histogram(s)..." << std::endl;);
             for (auto p = 0; p < width * height; p++) {
                 auto val = standardCube[p];
-                    if (!std::isnan(val)) {
+                    if (std::isfinite(val)) {
                         channelHistogramFunc(val);
                         cubeHistogramFunc(val);
                     }


### PR DESCRIPTION
This fixes segfaults caused by an incorrect histogram bin index calculation which is in turn caused by incorrect handling of INF values. This probably fixes an issue recently reported by Pawsey. A few other minor issues were corrected.

Note that as a side effect of this, the `NAN_COUNT` statistic now also includes INF values. This behaviour should be consistent with the way that statistics are calculated in CARTA, but we should perhaps rename these datasets or switch to storing the number of valid values instead.