### PR TITLE
Add a configurable memory limit for conversions

### DIFF
--- a/Converter.cc
+++ b/Converter.cc
@@ -64,8 +64,20 @@ void Converter::copyAndCalculate() {
     // implemented in subclasses
 }
 
-void Converter::reportMemoryUsage() {
+MemoryUsage Converter::calculateMemoryUsage() {
     // implemented in subclasses
+}
+
+void Converter::reportMemoryUsage() {
+    MemoryUsage m = calculateMemoryUsage();
+
+    std::cout << "APPROXIMATE MEMORY REQUIREMENTS:" << std::endl;
+    
+    for (auto& kv : m.sizes) {
+        std::cout << kv.first << ":\t" << kv.second * 1e-9 << " GB" << std::endl;
+    }
+
+    std::cout << "TOTAL:\t" << m.total * 1e-9 << "GB" << m.note << std::endl;
 }
 
 void Converter::convert() {

--- a/Converter.h
+++ b/Converter.h
@@ -12,6 +12,14 @@
 #include "Timer.h"
 #include "Util.h"
 
+struct MemoryUsage {
+    MemoryUsage() : total(0) {}
+    
+    std::unordered_map<std::string, hsize_t> sizes;
+    hsize_t total;
+    std::string note;
+};
+
 class Converter {
 public:
     Converter() {}
@@ -20,7 +28,8 @@ public:
     
     static std::unique_ptr<Converter> getConverter(std::string inputFileName, std::string outputFileName, bool slow, bool progress);
     void convert();
-    virtual void reportMemoryUsage();
+    void reportMemoryUsage();
+    virtual MemoryUsage calculateMemoryUsage();
     
 protected:
     virtual void copyAndCalculate();
@@ -66,7 +75,7 @@ protected:
 class FastConverter : public Converter {
 public:
     FastConverter(std::string inputFileName, std::string outputFileName, bool progress);
-    void reportMemoryUsage() override;
+    MemoryUsage calculateMemoryUsage() override;
     
 protected:
     void copyAndCalculate() override;
@@ -76,7 +85,7 @@ protected:
 class SlowConverter : public Converter {
 public:
     SlowConverter(std::string inputFileName, std::string outputFileName, bool progress);
-    void reportMemoryUsage() override;
+    MemoryUsage calculateMemoryUsage() override;
     
 protected:
     void copyAndCalculate() override;

--- a/README.md
+++ b/README.md
@@ -12,3 +12,20 @@ To install:
     cd build
     cmake ..
     make
+
+## Commandline options
+
+Run the executable with no parameters to see a list of options. The most important are:
+
+```
+-o      Output filename
+-s      Use slower but less memory-intensive method (enable if memory allocation fails)
+-p      Print progress output (by default the program is silent)
+-m      Report predicted memory usage and exit without performing the conversion
+```
+
+## Configuration
+
+A system administrator may set a memory usage limit in the `/etc/fits2idiarc` configuration file.
+The executable will not attempt to convert a file if the predicted memory usage exceeds this limit.
+A value of `0` means that there is no limit. Use a very small value (like `1`) to disable all conversions.

--- a/common.h
+++ b/common.h
@@ -24,7 +24,7 @@
 
 #define SCHEMA_VERSION "0.3"
 #define HDF5_CONVERTER "fits2idia"
-#define HDF5_CONVERTER_VERSION "0.1.14"
+#define HDF5_CONVERTER_VERSION "0.1.15"
 
 #define TILE_SIZE (hsize_t)512
 #define MIN_MIPMAP_SIZE (hsize_t)128

--- a/static/fits2idiarc
+++ b/static/fits2idiarc
@@ -1,0 +1,4 @@
+# Refuse to convert a file if the estimated memory use exceeds this limit in bytes.
+# Must be a positive integer. A value of 0 means that there is no limit.
+# Set to a small number (like 1) to disable all conversions.
+memory_limit = 0


### PR DESCRIPTION
@Jordatious this should fix #43.

I'm using an unsigned integer type for the value, so for simplicity a value of zero means no limit, and you'd use a very small value like `1` (byte) to disable all conversions on a login node. If anyone feels strongly that zero should mean zero and there should be special handling for an unset value, I can change this.