### PR TITLE
3rd axis of dataset can be included in mipmap calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ important are:
 -s      Use slower but less memory-intensive method (enable if memory allocation fails)
 -p      Print progress output (by default the program is silent)
 -m      Report predicted memory usage and exit without performing the conversion
+-z      Include calculation of mipmaps along 3rd axis of dataset
 ```
 
 ## Configuration

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -5,7 +5,7 @@
 
 #include "Converter.h"
 
-Converter::Converter(std::string inputFileName, std::string outputFileName, bool progress, bool zMips) : timer(), progress(progress) {
+Converter::Converter(std::string inputFileName, std::string outputFileName, bool progress, bool zMips) : timer(), progress(progress), zMips(zMips) {
     TIMER(timer.start("Setup"););
     
     openFitsFile(&inputFilePtr, inputFileName);

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -5,7 +5,7 @@
 
 #include "Converter.h"
 
-Converter::Converter(std::string inputFileName, std::string outputFileName, bool progress) : timer(), progress(progress) {
+Converter::Converter(std::string inputFileName, std::string outputFileName, bool progress, bool zMips) : timer(), progress(progress) {
     TIMER(timer.start("Setup"););
     
     openFitsFile(&inputFilePtr, inputFileName);
@@ -39,7 +39,7 @@ Converter::Converter(std::string inputFileName, std::string outputFileName, bool
     }
     
     // MIPMAPS
-    mipMaps = MipMaps(standardDims, tileDims);
+    mipMaps = MipMaps(standardDims, tileDims, zMips);
     
     // Prepare output file
     this->outputFileName = outputFileName;
@@ -52,11 +52,11 @@ Converter::~Converter() {
     closeFitsFile(inputFilePtr);
 }
 
-std::unique_ptr<Converter> Converter::getConverter(std::string inputFileName, std::string outputFileName, bool slow, bool progress) {
+std::unique_ptr<Converter> Converter::getConverter(std::string inputFileName, std::string outputFileName, bool slow, bool progress, bool zMips) {
     if (slow) {
-        return std::unique_ptr<Converter>(new SlowConverter(inputFileName, outputFileName, progress));
+        return std::unique_ptr<Converter>(new SlowConverter(inputFileName, outputFileName, progress, zMips));
     } else {
-        return std::unique_ptr<Converter>(new FastConverter(inputFileName, outputFileName, progress));
+        return std::unique_ptr<Converter>(new FastConverter(inputFileName, outputFileName, progress, zMips));
     }
 }
 

--- a/src/Converter.h
+++ b/src/Converter.h
@@ -36,6 +36,7 @@ protected:
     
     Timer timer;
     bool progress;
+    bool zMips;
     
     std::string tempOutputFileName;
     std::string outputFileName;

--- a/src/Converter.h
+++ b/src/Converter.h
@@ -23,10 +23,10 @@ struct MemoryUsage {
 class Converter {
 public:
     Converter() {}
-    Converter(std::string inputFileName, std::string outputFileName, bool progress);
+    Converter(std::string inputFileName, std::string outputFileName, bool progress, bool zMips);
     ~Converter();
     
-    static std::unique_ptr<Converter> getConverter(std::string inputFileName, std::string outputFileName, bool slow, bool progress);
+    static std::unique_ptr<Converter> getConverter(std::string inputFileName, std::string outputFileName, bool slow, bool progress, bool zMips);
     void convert();
     void reportMemoryUsage();
     virtual MemoryUsage calculateMemoryUsage() = 0;
@@ -74,7 +74,7 @@ protected:
 
 class FastConverter : public Converter {
 public:
-    FastConverter(std::string inputFileName, std::string outputFileName, bool progress);
+    FastConverter(std::string inputFileName, std::string outputFileName, bool progress, bool zMips);
     MemoryUsage calculateMemoryUsage() override;
     
 protected:
@@ -84,7 +84,7 @@ protected:
 
 class SlowConverter : public Converter {
 public:
-    SlowConverter(std::string inputFileName, std::string outputFileName, bool progress);
+    SlowConverter(std::string inputFileName, std::string outputFileName, bool progress, bool zMips);
     MemoryUsage calculateMemoryUsage() override;
     
 protected:

--- a/src/FastConverter.cc
+++ b/src/FastConverter.cc
@@ -12,7 +12,7 @@ MemoryUsage FastConverter::calculateMemoryUsage() {
     MemoryUsage m;
     
     m.sizes["Main dataset"] = depth * height * width * sizeof(float);
-    m.sizes["Mipmaps"] = MipMaps::size(standardDims, {depth, height, width});
+    m.sizes["Mipmaps"] = MipMaps::size(standardDims, {depth, height, width}, zMips);
     m.sizes["XY stats"] = Stats::size({depth}, numBins);
     
     if (depth > 1) {

--- a/src/FastConverter.cc
+++ b/src/FastConverter.cc
@@ -6,7 +6,7 @@
 #include "Converter.h"
 
 // TODO do we need these?
-FastConverter::FastConverter(std::string inputFileName, std::string outputFileName, bool progress) : Converter(inputFileName, outputFileName, progress) {}
+FastConverter::FastConverter(std::string inputFileName, std::string outputFileName, bool progress, bool zMips) : Converter(inputFileName, outputFileName, progress, zMips) {}
 
 MemoryUsage FastConverter::calculateMemoryUsage() {
     MemoryUsage m;

--- a/src/MipMap.cc
+++ b/src/MipMap.cc
@@ -98,7 +98,7 @@ MipMaps::MipMaps(std::vector<hsize_t> standardDims, const std::vector<hsize_t>& 
 
 }
 
-hsize_t MipMaps::size(const std::vector<hsize_t>& standardDims, const std::vector<hsize_t>& standardBufferDims) {
+hsize_t MipMaps::size(const std::vector<hsize_t>& standardDims, const std::vector<hsize_t>& standardBufferDims, bool zMips) {
     hsize_t size = 0;
     int mipXY = 1;
     int mipZ = 1;
@@ -107,7 +107,7 @@ hsize_t MipMaps::size(const std::vector<hsize_t>& standardDims, const std::vecto
     int N = standardDims.size();
     
     do {
-        if (N > 2) {
+        if (N > 2 && zMips) {
             do {
                 if (mipXY > 1 || mipZ > 1)
                     size += (sizeof(double) + sizeof(int)) * product(bufferDims);

--- a/src/MipMap.cc
+++ b/src/MipMap.cc
@@ -73,7 +73,7 @@ void MipMap::resetBuffers() {
 
 // MipMaps
 
-MipMaps::MipMaps(std::vector<hsize_t> standardDims, const std::vector<hsize_t>& chunkDims) : standardDims(standardDims), chunkDims(chunkDims) {
+MipMaps::MipMaps(std::vector<hsize_t> standardDims, const std::vector<hsize_t>& chunkDims, bool zMips) : standardDims(standardDims), chunkDims(chunkDims) {
     auto dims = standardDims;
     int N = dims.size();
     int mipXY = 1;
@@ -81,7 +81,7 @@ MipMaps::MipMaps(std::vector<hsize_t> standardDims, const std::vector<hsize_t>& 
     
     // We keep going until we have a mipmap which fits entirely within the minimum size
     do {
-        if (N > 2) {
+        if (N > 2 && zMips) {
             do {
                 if (mipXY > 1 || mipZ > 1)
                     mipMaps.push_back(MipMap(dims, mipXY, mipZ));

--- a/src/MipMap.h
+++ b/src/MipMap.h
@@ -61,7 +61,8 @@ struct MipMaps {
     MipMaps(std::vector<hsize_t> standardDims, const std::vector<hsize_t>& chunkDims, bool zMips);
     
     // We need the dataset dimensions to work out how many mipmaps we have
-    static hsize_t size(const std::vector<hsize_t>& standardDims, const std::vector<hsize_t>& standardBufferDims);
+    static hsize_t size(const std::vector<hsize_t>& standardDims, const std::vector<hsize_t>& standardBufferDims, bool zMips);
+    
     
     void createDatasets(H5::Group group);
     void createBuffers(const std::vector<hsize_t>& standardBufferDims);

--- a/src/MipMap.h
+++ b/src/MipMap.h
@@ -12,18 +12,18 @@
 // A single mipmap
 struct MipMap {
     MipMap() {};
-    MipMap(const std::vector<hsize_t>& datasetDims, int mip);
+    MipMap(const std::vector<hsize_t>& datasetDims, int mipXY, int mipZ);
     ~MipMap();
     
     void createDataset(H5::Group group, const std::vector<hsize_t>& chunkDims);
     void createBuffers(std::vector<hsize_t>& bufferDims);
     
-    void accumulate(double val, hsize_t x, hsize_t y, hsize_t totalChannelOffset) {
-        hsize_t mipIndex = totalChannelOffset * width * height + (y / mip) * width + (x / mip);
+    void accumulate(double val, hsize_t x, hsize_t y, hsize_t z) {
+        hsize_t mipIndex = (z / mipZ) * width * height + (y / mipXY) * width + (x / mipXY);
         vals[mipIndex] += val;
         count[mipIndex]++;
     }
-
+    
     void calculate() {
         for (hsize_t mipIndex = 0; mipIndex < bufferSize; mipIndex++) {
             if (count[mipIndex]) {
@@ -38,7 +38,8 @@ struct MipMap {
     void resetBuffers();
     
     std::vector<hsize_t> datasetDims;
-    int mip;
+    int mipXY;
+    int mipZ;
     
     H5::DataSet dataset;
     
@@ -65,9 +66,9 @@ struct MipMaps {
     void createDatasets(H5::Group group);
     void createBuffers(const std::vector<hsize_t>& standardBufferDims);
     
-    void accumulate(double val, hsize_t x, hsize_t y, hsize_t totalChannelOffset) {
+    void accumulate(double val, hsize_t x, hsize_t y, hsize_t z) {
         for (auto& mipMap : mipMaps) {
-            mipMap.accumulate(val, x, y, totalChannelOffset);
+            mipMap.accumulate(val, x, y, z);
         }
     }
 

--- a/src/MipMap.h
+++ b/src/MipMap.h
@@ -58,7 +58,7 @@ struct MipMap {
 // A set of mipmaps
 struct MipMaps {
     MipMaps() {};
-    MipMaps(std::vector<hsize_t> standardDims, const std::vector<hsize_t>& chunkDims);
+    MipMaps(std::vector<hsize_t> standardDims, const std::vector<hsize_t>& chunkDims, bool zMips);
     
     // We need the dataset dimensions to work out how many mipmaps we have
     static hsize_t size(const std::vector<hsize_t>& standardDims, const std::vector<hsize_t>& standardBufferDims);

--- a/src/SlowConverter.cc
+++ b/src/SlowConverter.cc
@@ -5,7 +5,7 @@
 
 #include "Converter.h"
 
-SlowConverter::SlowConverter(std::string inputFileName, std::string outputFileName, bool progress) : Converter(inputFileName, outputFileName, progress) {}
+SlowConverter::SlowConverter(std::string inputFileName, std::string outputFileName, bool progress, bool zMips) : Converter(inputFileName, outputFileName, progress, zMips) {}
 
 MemoryUsage SlowConverter::calculateMemoryUsage() {
     MemoryUsage m;

--- a/src/SlowConverter.cc
+++ b/src/SlowConverter.cc
@@ -11,7 +11,7 @@ MemoryUsage SlowConverter::calculateMemoryUsage() {
     MemoryUsage m;
 
     m.sizes["Main dataset"] = height * width * sizeof(float);
-    m.sizes["Mipmaps"] = MipMaps::size(standardDims, {1, height, width});
+    m.sizes["Mipmaps"] = MipMaps::size(standardDims, {1, height, width}, zMips);
     m.sizes["XY stats"] = Stats::size({depth}, numBins);
     
     if (depth > 1) {

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -31,14 +31,16 @@ std::vector<hsize_t> extend(const std::vector<hsize_t>& left, const std::vector<
     return result;
 }
 
-std::vector<hsize_t> mipDims(const std::vector<hsize_t>& dims, int mip) {
+std::vector<hsize_t> mipDims(const std::vector<hsize_t>& dims, int mipXY, int mipZ) {
     int N = dims.size();
     auto mipDims = dims;
-    
-    for (auto i = std::max(0, N - 2); i < N; i++) {
-        mipDims[i] = std::ceil((float)mipDims[i] / mip);
+    if (mipXY > 1) {
+        for (auto i = std::max(0, N - 2); i < N; i++) {
+            mipDims[i] = std::ceil((float)mipDims[i] / mipXY);
+        }
     }
-    
+    if (mipZ > 1 && N > 2)
+        mipDims[N - 3] = std::ceil((float)mipDims[N - 3] / mipZ);
     return mipDims;
 }
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -11,7 +11,7 @@
 std::vector<std::string> split(const std::string &str, char separator);
 std::vector<hsize_t> trimAxes(const std::vector<hsize_t>& dims, int N);
 std::vector<hsize_t> extend(const std::vector<hsize_t>& left, const std::vector<hsize_t>& right);
-std::vector<hsize_t> mipDims(const std::vector<hsize_t>& dims, int mip);
+std::vector<hsize_t> mipDims(const std::vector<hsize_t>& dims, int mipXY, int mipZ);
 hsize_t product(const std::vector<hsize_t>& dims);
 
 template <typename T>

--- a/src/main.cc
+++ b/src/main.cc
@@ -9,7 +9,7 @@
 #include <sstream>
 #include "Converter.h"
 
-bool getOptions(int argc, char** argv, std::string& inputFileName, std::string& outputFileName, bool& slow, bool& progress, bool& onlyReportMemory) {
+bool getOptions(int argc, char** argv, std::string& inputFileName, std::string& outputFileName, bool& slow, bool& progress, bool& onlyReportMemory, bool& zMips) {
     extern int optind;
     extern char *optarg;
     
@@ -19,15 +19,16 @@ bool getOptions(int argc, char** argv, std::string& inputFileName, std::string& 
     std::ostringstream usage;
     usage << "IDIA FITS to HDF5 converter version " << HDF5_CONVERTER_VERSION 
     << " using IDIA schema version " << SCHEMA_VERSION << std::endl
-    << "Usage: fits2idia [-o output_filename] [-s] [-p] [-m] input_filename" << std::endl << std::endl
+    << "Usage: fits2idia [-o output_filename] [-s] [-p] [-m] [-z] input_filename" << std::endl << std::endl
     << "Options:" << std::endl 
     << "-o\tOutput filename" << std::endl 
     << "-s\tUse slower but less memory-intensive method (enable if memory allocation fails)" << std::endl 
     << "-p\tPrint progress output (by default the program is silent)" << std::endl
     << "-m\tReport predicted memory usage and exit without performing the conversion" << std::endl
-    << "-q\tSuppress all non-error output. Deprecated; this is now the default." << std::endl;
+    << "-q\tSuppress all non-error output. Deprecated; this is now the default." << std::endl
+    << "-z\tCalculate mipmaps for depth" << std::endl;
     
-    while ((opt = getopt(argc, argv, ":o:spqm")) != -1) {
+    while ((opt = getopt(argc, argv, ":o:spqmz")) != -1) {
         switch (opt) {
             case 'o':
                 outputFileName.assign(optarg);
@@ -45,6 +46,9 @@ bool getOptions(int argc, char** argv, std::string& inputFileName, std::string& 
             case 'm':
                 // only print memory usage and exit
                 onlyReportMemory = true;
+                break;
+            case 'z':
+                zMips = true;
                 break;
             case ':':
                 err = true;
@@ -94,8 +98,9 @@ int main(int argc, char** argv) {
     bool slow(false);
     bool progress(false);
     bool onlyReportMemory(false);
+    bool zMips(false);
     
-    if (!getOptions(argc, argv, inputFileName, outputFileName, slow, progress, onlyReportMemory)) {
+    if (!getOptions(argc, argv, inputFileName, outputFileName, slow, progress, onlyReportMemory, zMips)) {
         return 1;
     }
     
@@ -121,7 +126,7 @@ int main(int argc, char** argv) {
     std::unique_ptr<Converter> converter;
         
     try {
-        converter = Converter::getConverter(inputFileName, outputFileName, slow, progress);
+        converter = Converter::getConverter(inputFileName, outputFileName, slow, progress, zMips);
         
         if (onlyReportMemory) {
             converter->reportMemoryUsage();

--- a/src/main.cc
+++ b/src/main.cc
@@ -26,8 +26,8 @@ bool getOptions(int argc, char** argv, std::string& inputFileName, std::string& 
     << "-p\tPrint progress output (by default the program is silent)" << std::endl
     << "-m\tReport predicted memory usage and exit without performing the conversion" << std::endl
     << "-q\tSuppress all non-error output. Deprecated; this is now the default." << std::endl
-    << "-z\tCalculate mipmaps for depth" << std::endl;
-    
+    << "-z\tInclude axis 3 in mipmap calculation (currently not compatible with -s mode)." << std::endl;
+
     while ((opt = getopt(argc, argv, ":o:spqmz")) != -1) {
         switch (opt) {
             case 'o':
@@ -103,7 +103,12 @@ int main(int argc, char** argv) {
     if (!getOptions(argc, argv, inputFileName, outputFileName, slow, progress, onlyReportMemory, zMips)) {
         return 1;
     }
-    
+
+    if (slow && zMips){
+        std::cerr << "Currently unable to include depth in mipmap calculation for -s mode." << std::endl;
+        return -1;
+    }
+
     hsize_t memoryLimit(0);
     
     std::ifstream rcFile("/etc/fits2idiarc");


### PR DESCRIPTION
closes #51 

This adds the -z option to fits2idia that will include the 3rd axis (if available) of the fits dataset in the calculation of mipmaps. This is only implemented for the 

The convertertest.py testing script was also updated with the -z option to allow testing of the converter's new ability.

Also added error message if -z and -s are both used as -z can only be used in "fast mode" currently.